### PR TITLE
Run cron on MacOS machine

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: borales/actions-yarn@v2.0.0


### PR DESCRIPTION
우분투 환경에서는 SVG를 PNG 로 변환 시 문자열이 깨지는 현상이 일어납니다.