### PR TITLE
Replace actions-yarn to setup-node

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,12 +8,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: borales/actions-yarn@v2.0.0
+      - name: Use Node.js
+        uses: actions/setup-node@v1
         with:
-          cmd: install
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: start
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn
+      - name: Run cron job
+        run: yarn start
         env:
           ACCESS_TOKEN_KEY: ${{ secrets.ACCESS_TOKEN_KEY }}
           ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET  }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: borales/actions-yarn@v2.0.0
+      - name: Use Node.js
+        uses: actions/setup-node@v1
         with:
-          cmd: install
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: test
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn
+      - name: Run test
+        run: yarn test


### PR DESCRIPTION
setup-node now include yarn CLI

Reference: https://help.github.com/en/actions/language-and-framework-guides/using-nodejs-with-github-actions#example-using-yarn