### PR TITLE
Use promise.all in integration test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,10 +3,12 @@ import parseSVG from './parseSvg'
 import { readFile } from './utils/fs'
 
 test('Compare snapshot', async () => {
-  const graph = await getGraph()
-  const result = parseSVG(graph, new Date('2020-01-12'))
+  const [graph, expectSVG] = await Promise.all([
+    getGraph(),
+    readFile('mock/expect.svg', { encoding: 'utf8' }),
+  ])
 
-  const expectSVG = await readFile('mock/expect.svg', { encoding: 'utf8' })
+  const result = parseSVG(graph, new Date('2020-01-12'))
 
   expect(result).toBe(expectSVG)
 })


### PR DESCRIPTION
Reduce the bottleneck of waiting time
refreance article : https://jaeheon.kr/161